### PR TITLE
Add support for UPS status change-based alert filtering

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -78,6 +78,7 @@ basic_alerts:
   ups_status:
     enabled: true
     acceptable: ["ol", "online"] # acceptable ups operational statuses
+#    alert_when_status_changed: true # optional, enable If you only want to send an alert when the UPS status has changed
     message: "ups status not in acceptable list"
 
 ###############################################################################

--- a/nutalert/alert.py
+++ b/nutalert/alert.py
@@ -109,8 +109,31 @@ def check_ups_status(basic_alerts, env):
             message = "ups status not in acceptable list"
         else:
             message = basic_alerts["ups_status"]["message"]
+        if _should_skip_due_to_unchanged_status(basic_alerts, env["ups_status"]):
+            return None
         return f"{message} ({env['ups_status']})"
     return None
+
+
+previous_ups_status: str = ""
+
+
+def _should_skip_due_to_unchanged_status(basic_alerts, current_status: str) -> bool:
+    global previous_ups_status
+    if not _is_enabled_alert_when_status_changed(basic_alerts):
+        return False
+
+    logger.info(f"'alert_when_status_changed' is true")
+    if current_status == previous_ups_status:
+        logger.info(f"ups status unchanged: {current_status} (no alert)")
+        return True
+
+    previous_ups_status = current_status
+    return False
+
+
+def _is_enabled_alert_when_status_changed(basic_alerts) -> bool:
+    return basic_alerts["ups_status"].get('alert_when_status_changed', False)
 
 
 def check_basic_alerts(config, env):


### PR DESCRIPTION
This pull request introduces an simple enhancement to the UPS status alert mechanism.
Now, alerts can be configured to trigger only when the UPS status has changed, avoiding repeated notifications for the same status.

✅ Key Changes:
	•	Added '`alert_when_status_changed`' configuration under 'basic_alerts.ups_status'
	•	Introduced '`_should_skip_due_to_unchanged_status()`' helper function
	•	Improved '`check_ups_status()`' logic to respect the status change setting
	•	Updated internal tracking with '`previous_ups_status`' to compare state transitions

⚙️ How to Use:
To enable this feature, add the following option to your config:
```yaml
basic_alerts:
  ups_status:
    enabled: true
    acceptable: ["ol", "online"]
    alert_when_status_changed: true
```

This helps reduce alert noise and ensures notifications are sent only when relevant changes occur.